### PR TITLE
Add options for pump battery age statuslight

### DIFF
--- a/plugins/main/src/main/kotlin/app/aaps/plugins/main/general/overview/OverviewPlugin.kt
+++ b/plugins/main/src/main/kotlin/app/aaps/plugins/main/general/overview/OverviewPlugin.kt
@@ -279,6 +279,8 @@ class OverviewPlugin @Inject constructor(
                 addPreference(AdaptiveIntPreference(ctx = context, intKey = IntKey.OverviewResCritical, title = R.string.statuslights_res_critical))
                 addPreference(AdaptiveIntPreference(ctx = context, intKey = IntKey.OverviewBattWarning, title = R.string.statuslights_bat_warning))
                 addPreference(AdaptiveIntPreference(ctx = context, intKey = IntKey.OverviewBattCritical, title = R.string.statuslights_bat_critical))
+                addPreference(AdaptiveIntPreference(ctx = context, intKey = IntKey.OverviewBageWarning, title = R.string.statuslights_bage_warning))
+                addPreference(AdaptiveIntPreference(ctx = context, intKey = IntKey.OverviewBageCritical, title = R.string.statuslights_bage_critical))
                 addPreference(AdaptiveClickPreference(ctx = context, stringKey = StringKey.OverviewCopySettingsFromNs, title = R.string.statuslights_copy_ns,
                                                       onPreferenceClickListener = {
                                                           nsSettingStatus.copyStatusLightsNsSettings(context)


### PR DESCRIPTION
Currently, there is no option to configure the status light for the warning and critical thresholds of the pump battery's age. Since these keys already exist in the preferences storage and are used to display the status light, I would prefer the ability to adjust them directly within AAPS. All other thresholds can be configured locally, except for those related to the pump battery age.

Additionally, the relevant `IntKeys` and corresponding strings, including translations, are already present in AAPS.

The expected result appears as follows:
![AAPS-2025-01-06-190328_002](https://github.com/user-attachments/assets/dd8270a6-feec-4515-8e5f-cdc7a77a627b)